### PR TITLE
Add docker for DB, PHP and DB manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # sensitive info
 .env
+
+# IDE related
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-DockerfileSELECT * FROM `inventory_purchase_order_consumable` WHERE `ipoc_id` = '9328';FROM php:7.2.2-apache
+FROM php:7.2.2-apache
 
 RUN a2enmod rewrite
 RUN docker-php-ext-install mysqli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+DockerfileSELECT * FROM `inventory_purchase_order_consumable` WHERE `ipoc_id` = '9328';FROM php:7.2.2-apache
+
+RUN a2enmod rewrite
+RUN docker-php-ext-install mysqli
+
+ADD . /var/www/html

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 start_docker:
-	docker-compose -f docker-compose.yml up
+	docker-compose -f docker-compose.yml up -d
+
+migrate:
+	docker-compose run web php bango migrate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+Makefilestart_docker:
+	docker-compose -f docker-compose.yml up

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
-Makefilestart_docker:
+start_docker:
 	docker-compose -f docker-compose.yml up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+# Use root/example as user/password credentials
+version: '3.1'
+
+services:
+
+  db:
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+
+  adminer:
+    image: adminer
+    restart: always
+    links:
+      - db
+    ports:
+      - 8081:8080
+
+  web:
+    build: .
+    container_name: php_web
+    links:
+      - db
+    depends_on:
+      - db
+    ports:
+      - "8100:80"
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
Nice project, seems like a fun project to contribute to! 😄 

At my job, we don't install MySQL/PHP/Web server on our local machines, we use docker. So I wasn't able to setup the project initially.

This PR adds a simple docker configuration (using the [main MySQL image example yml](https://hub.docker.com/_/mysql) file and a tag of the [main PHP image](https://hub.docker.com/layers/php/library/php/7.2.2-apache/images/sha256-b6cfac38401182586b637d74a7a717905554fc9231df9f6d11c217b19348b8b5?context=explore) which includes apache)

The PHP image doesn't have htaccess' rewrite module enabled by default, nor does it have mysqli extension, so those have been added via `Dockerfile`

A `Makefile` was added so all you need to do is run `$ make` to get the docker containers running

After running `make`:

- To migrate the DB, run `make migrate`

- To view the app in the browser, visit [http://localhost:8100](http://localhost:8100)

- To view the DB manager (Adminer), visit [http://localhost:8081](http://localhost:8081)

The MySQL credentials have been left as default (`root` and `example`) but this can be changed/configured at a later time. The `server` or `host` is `db` (i.e. the name of the database container)