### PR TITLE
Fix call to renamed CLI function

### DIFF
--- a/bango
+++ b/bango
@@ -7,7 +7,7 @@ use \Bango\Cli;
 
 try
 {
-    Cli::parse_action($argv);
+    Cli::parseAction($argv);
 }
 catch (Exception $e)
 {


### PR DESCRIPTION
Was getting `Fatal error: Uncaught Error: Call to undefined method Bango\Cli::parse_action() in /var/www/html/bango:10` due to https://github.com/hollandsgabe/bango/commit/3895ebcd18577293e41cc19b9e135dbb5b4c7117