### PR TITLE
Change docker to use PHP 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.2-apache
+FROM php:8.0.0alpha3-apache
 
 RUN a2enmod rewrite
 RUN docker-php-ext-install mysqli

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ all: start
 start:
 	docker-compose -f docker-compose.yml up -d
 
+build:
+	docker-compose -f docker-compose.yml up --build -d
+
 stop:
+	docker-compose stop
+
+remove:
 	docker-compose down
 
 migrate:

--- a/README.md
+++ b/README.md
@@ -226,6 +226,16 @@ $ php bango migrate
 
 If everything went ok, you should receive back a `Migration successful` message.
 
+### Docker
+
+To use Docker to serve the application, run `make`
+
+This will create the relevant containers and make the app available on http://localhost:8100
+
+A GUI to manage the DB is available on http://localhost:8081
+
+To run the migrations in the container, run `make migrate`
+
 ## Security Vulnerabilities
 
 If you discover a security vulnerability within Bango, please send an e-mail to Gabriel Moreno via [gamoreno@urbe.edu.ve](mailto:gamoreno@urbe.edu.ve). All security vulnerabilities will be promptly addressed.


### PR DESCRIPTION
Pull in PHP 8 via Docker.

Also adds a `make build` command (which re-reads the Dockerfile, instead of starting up using the previous php7 build)

Also adds `make stop` to simply stop docker containers, and `make remove` to completely remove containers (if you want to delete everything and start from scratch).

You can test PHP 8 by doing `phpinfo();` in `index.php` - you'll see PHP 8 in the title of that page.